### PR TITLE
Add PSR7 Swoole bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 /vendor/
+composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 /vendor/
 composer.lock
+.php_cs.cache

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,184 @@
+<?php
+
+/*
+ * PHP Coding Standards Fixer Config file for PHP7.0 and up
+ *
+ * @see https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/master/README.rst
+ */
+
+$header = <<<'EOF'
+EOF;
+
+$finder = PhpCsFixer\Finder::create()
+    ->exclude(['tests/Fake', 'tests/tmp'])
+    ->in(__DIR__);
+
+return \PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        '@PHP70Migration:risky' => true,
+        'align_multiline_comment' => true,
+        'array_indentation' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'backtick_to_shell_exec' => true,
+        'binary_operator_spaces' => true, // @Symfony
+        'blank_line_after_opening_tag' => true, // @Symfony
+        'blank_line_before_return' => true,
+        'blank_line_before_statement' => ['statements' => ['break', 'continue', 'declare', 'return', 'throw']], // @Symfony
+        'cast_spaces' => true, // @Symfony
+        'class_attributes_separation' => ['elements' => ['const', 'method']], // @Symfony
+//      'class_keyword_remove' => true,
+        'combine_consecutive_issets' => true,
+        'combine_consecutive_unsets' => true,
+//      'comment_to_phpdoc' => true,
+        'compact_nullable_typehint' => true,
+        'concat_space' => ['spacing' => 'one'], // @Symfony
+//      'date_time_immutable' => true,
+        'declare_equal_normalize' => true, // @Symfony
+        'dir_constant' => true, // @Symfony:risky
+        'ereg_to_preg' => true, // @Symfony:risky
+        'error_suppression' => true, // @Symfony:risky
+        'escape_implicit_backslashes' => true,
+        'explicit_indirect_variable' => true,
+        'explicit_string_variable' => true,
+//      'final_internal_class' => true,
+        'fully_qualified_strict_types' => true,
+        'function_to_constant' => true, // @Symfony:risky
+        'function_typehint_space' => true, // @Symfony
+        'general_phpdoc_annotation_remove' => ['author', 'category', 'package', 'copyright', 'version'],
+        'header_comment' => ['header' => $header, 'comment_type' => 'comment'],
+        'heredoc_to_nowdoc' => true,
+        'include' => true, // @Symfony
+//      'increment_style' => 'pre', // @Symfony
+        'indentation_type' => true,
+        'is_null' => ['use_yoda_style' => false], // @Symfony:risky
+        'linebreak_after_opening_tag' => true,
+//      'list_syntax' => true,
+//      'logical_operators' => true,
+        'lowercase_cast' => true, // @Symfony
+        'lowercase_static_reference' => true, // @Symfony
+        'magic_constant_casing' => true,
+//      'mb_str_functions' => true,
+        'method_chaining_indentation' => true,
+        'method_separation' => true,
+        'modernize_types_casting' => true, // @Symfony:risky
+        'multiline_comment_opening_closing' => true,
+        'multiline_whitespace_before_semicolons' => true,
+//      'native_constant_invocation' => true,
+        'native_function_casing' => true, // @Symfony
+//      'native_function_invocation' => true,
+//      'new_with_braces' => true, // @Symfony
+        'no_alias_functions' => true, // @Symfony:risky
+        'no_alternative_syntax' => true,
+        'no_binary_string' => true,
+        'no_blank_lines_after_class_opening' => true, // @Symfony
+        'no_blank_lines_after_phpdoc' => true, // @Symfony
+//      'no_blank_lines_before_namespace' => true,
+        'no_empty_comment' => true, // @Symfony
+        'no_empty_phpdoc' => true, // @Symfony
+        'no_empty_statement' => true, // @Symfony
+        'no_extra_blank_lines' => true,
+        'no_homoglyph_names' => true, // @Symfony:risky
+        'no_leading_import_slash' => true, // @Symfony
+        'no_leading_namespace_whitespace' => true, // @Symfony
+        'no_mixed_echo_print' => true, // @Symfony
+        'no_multiline_whitespace_around_double_arrow' => true, // @Symfony
+        'no_null_property_initialization' => true,
+        'no_php4_constructor' => true,
+        'no_short_bool_cast' => true, // @Symfony
+        'no_short_echo_tag' => false,
+        'no_singleline_whitespace_before_semicolons' => true, // @Symfony
+        'no_spaces_around_offset' => true, // @Symfony
+        'no_superfluous_elseif' => true,
+        'no_superfluous_phpdoc_tags' => true,
+        'no_trailing_comma_in_list_call' => true, // @Symfony
+        'no_trailing_comma_in_singleline_array' => true, // @Symfony
+        'no_trailing_whitespace' => true,
+        'no_trailing_whitespace_in_comment' => true,
+        'no_unneeded_control_parentheses' => true, // @Symfony
+        'no_unneeded_curly_braces' => true, // @Symfony
+        'no_unneeded_final_method' => true, // @Symfony
+        'no_unreachable_default_argument_value' => true,
+        'no_unset_on_property' => true,
+        'no_unused_imports' => true,
+        'no_useless_else' => true,
+        'no_useless_return' => true,
+        'no_whitespace_before_comma_in_array' => true, // @Symfony
+        'no_whitespace_in_blank_line' => true, // @Symfony
+        'non_printable_character' => true, // @Symfony
+        'normalize_index_brace' => true, // @Symfony
+        'not_operator_with_space' => false,
+        'not_operator_with_successor_space' => true,
+        'object_operator_without_whitespace' => true, // @Symfony
+        'ordered_class_elements' => true,
+        'ordered_imports' => true,
+        'php_unit_construct' => true, // @Symfony:risky
+        'php_unit_dedicate_assert' => true,
+        'php_unit_expectation' => true,
+        'php_unit_fqcn_annotation' => true, // @Symfony
+//      'php_unit_internal_class' => true, // @Symfony]
+//      'php_unit_mock' => true,
+        'php_unit_namespaced' => true,
+        'php_unit_no_expectation_annotation' => true,
+        'php_unit_ordered_covers' => true,
+        'php_unit_set_up_tear_down_visibility' => true,
+        'php_unit_strict' => true,
+//      'php_unit_test_annotation' => true,
+//      'php_unit_test_case_static_method_calls' => true,
+//      'php_unit_test_class_requires_covers' => true,
+//      'phpdoc_add_missing_param_annotation' => true,
+        'phpdoc_align' => true, // @Symfony]
+        'phpdoc_annotation_without_dot' => true, // @Symfony]
+        'phpdoc_indent' => true, // @Symfony]
+        'phpdoc_inline_tag' => true, // @Symfony]
+        'phpdoc_no_access' => true, // @Symfony]
+        'phpdoc_no_alias_tag' => true, // @Symfony
+        'phpdoc_no_empty_return' => true, // @Symfony
+        'phpdoc_no_package' => true, // @Symfony
+//      'phpdoc_no_useless_inheritdoc' => true, // @Symfony
+        'phpdoc_order' => true,
+        'phpdoc_return_self_reference' => true, // @Symfony
+        'phpdoc_scalar' => true, // @Symfony
+        'phpdoc_separation' => true, // @Symfony
+        'phpdoc_single_line_var_spacing' => true, // @Symfony
+//      'phpdoc_summary' => true, // @Symfony
+        'phpdoc_to_comment' => true, // @Symfony
+        'phpdoc_trim' => true, // @Symfony
+        'phpdoc_trim_consecutive_blank_line_separation' => true,
+        'phpdoc_types' => true, // @Symfony
+        'phpdoc_types_order' => true, // @Symfony
+        'phpdoc_var_without_name' => true, // @Symfony
+        'protected_to_private' => true,
+        'psr0' => true,
+        'psr4' => true, // @Symfony:risky
+        'return_assignment' => true,
+        'return_type_declaration' =>  ['space_before' => 'one'],
+        'self_accessor' => true, // @Symfony:risky
+        'semicolon_after_instruction' => true, // @Symfony
+        'set_type_to_cast' => true, // @Symfony:risky
+        'short_scalar_cast' => true, // @Symfony:risky
+        'simplified_null_return' => true,
+        'single_blank_line_before_namespace' => true, // @Symfony
+//      'single_line_comment_style' => true, // @Symfony
+        'single_line_after_imports' => true,
+        'single_quote' => true, // @Symfony
+        'space_after_semicolon' => true, // @Symfony
+        'standardize_increment' => true, // @Symfony
+        'standardize_not_equals' => true, // @Symfony
+//      'static_lambda' => true,
+//      'strict_comparison' => true,
+        'strict_param' => true,
+//      'string_line_ending' => true,
+        'switch_case_semicolon_to_colon' => true,
+        'switch_case_space' => true,
+        'ternary_operator_spaces' => true,
+//      'trailing_comma_in_multiline_array' => true, // @Symfony
+        'trim_array_spaces' => true, // @Symfony
+        'unary_operator_spaces' => true, // @Symfony
+        'visibility_required' => true,
+//      'void_return' => true, // @PHP71Migration:risky
+        'whitespace_after_comma_in_array' => true, // @Symfony
+//      'yoda_style' => true // @Symfony
+    ])
+    ->setFinder($finder);

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,17 +20,14 @@ before_install:
   - composer validate
 install:
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then composer require --dev phpstan/phpstan-shim ^0.9 friendsofphp/php-cs-fixer ^2.13; fi
-  - printf "\n" | pecl install swoole
-  - echo 'extension = "swoole.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
+  - yes '' | pecl install swoole
   - php -m
   - composer update $DEPENDENCIES
   - php tests/bin/swoole.php &
-  - sleep 10
 script:
   - ./vendor/bin/phpunit $COVERAGE;
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/php-cs-fixer --dry-run -v fix; fi
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then phpenv config-add /tmp/xdebug.ini; ./vendor/bin/phpunit --coverage-clover=coverage.clover; else ./vendor/bin/phpunit; fi
-  - curl -i  http://127.0.0.1:8080/
 after_script:
 - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - php -m
   - composer update $DEPENDENCIES
   - php tests/bin/swoole.php &
-  - sleep 5
+  - sleep 10
 script:
   - ./vendor/bin/phpunit $COVERAGE;
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/php-cs-fixer --dry-run -v fix; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
   - php -m
   - composer update $DEPENDENCIES
   - MODULES="swoole.so:swoole" ./travis/modulecache.sh
-  - phpenv config-add tests/swoole.ini
 before_script:
   - php tests/bin/swoole.php &
   - sleep 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 - composer validate
 install:
 - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then composer require --dev phpstan/phpstan-shim ^0.9 friendsofphp/php-cs-fixer ^2.0; fi
-- pecl install -f swoole
+- printf "\n" | pecl install swoole
 - echo 'extension = "swoole.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
 - php -m
 - composer update $DEPENDENCIES

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
   - php -m
   - composer update $DEPENDENCIES
   - php tests/bin/swoole.php &
+  - sleep 5
 script:
   - ./vendor/bin/phpunit $COVERAGE;
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/php-cs-fixer --dry-run -v fix; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,23 +9,26 @@ cache:
   directories:
     - vendor
     - $HOME/.composer/cache
+    - ${TRAVIS_BUILD_DIR}/travis/module-cache
 env:
   matrix:
     - DEPENDENCIES=""
     - DEPENDENCIES="--prefer-lowest --prefer-stable"
 before_install:
+  - sh -c "mkdir -p ${TRAVIS_BUILD_DIR}/travis/module-cache/`php-config --vernum`"
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then cp $HOME/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini /tmp; fi
   - if [[ $TRAVIS_PHP_VERSION != '7.3' ]]; then phpenv config-rm xdebug.ini ; fi
   - composer self-update
   - composer validate
 install:
   - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then composer require --dev phpstan/phpstan-shim ^0.9 friendsofphp/php-cs-fixer ^2.13; fi
-  - yes '' | pecl install swoole
   - php -m
   - composer update $DEPENDENCIES
+  - MODULES="swoole.so:swoole" ./travis/modulecache.sh
+  - phpenv config-add tests/swoole.ini
+before_script:
   - php tests/bin/swoole.php &
 script:
-  - ./vendor/bin/phpunit $COVERAGE;
   - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then ./vendor/bin/php-cs-fixer --dry-run -v fix; fi
   - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi
   - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then phpenv config-add /tmp/xdebug.ini; ./vendor/bin/phpunit --coverage-clover=coverage.clover; else ./vendor/bin/phpunit; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,22 @@ env:
     - DEPENDENCIES=""
     - DEPENDENCIES="--prefer-lowest --prefer-stable"
 before_install:
-- if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then cp $HOME/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini /tmp; fi
-- if [[ $TRAVIS_PHP_VERSION != '7.3' ]]; then phpenv config-rm xdebug.ini ; fi
-- composer self-update
-- composer validate
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then cp $HOME/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini /tmp; fi
+  - if [[ $TRAVIS_PHP_VERSION != '7.3' ]]; then phpenv config-rm xdebug.ini ; fi
+  - composer self-update
+  - composer validate
 install:
-- if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then composer require --dev phpstan/phpstan-shim ^0.9 friendsofphp/php-cs-fixer ^2.0; fi
-- printf "\n" | pecl install swoole
-- echo 'extension = "swoole.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
-- php -m
-- composer update $DEPENDENCIES
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then composer require --dev phpstan/phpstan-shim ^0.9 friendsofphp/php-cs-fixer ^2.13; fi
+  - printf "\n" | pecl install swoole
+  - echo 'extension = "swoole.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
+  - php -m
+  - composer update $DEPENDENCIES
+  - php tests/bin/swoole.php &
 script:
   - ./vendor/bin/phpunit $COVERAGE;
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/php-cs-fixer --dry-run -v fix; fi
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi
   - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then phpenv config-add /tmp/xdebug.ini; ./vendor/bin/phpunit --coverage-clover=coverage.clover; else ./vendor/bin/phpunit; fi
+  - curl -i  http://127.0.0.1:8080/
 after_script:
 - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - phpenv config-add tests/swoole.ini
 before_script:
   - php tests/bin/swoole.php &
+  - sleep 10
 script:
   - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then ./vendor/bin/php-cs-fixer --dry-run -v fix; fi
   - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: php
+sudo: false
+dist: trusty
+php:
+  - 7.1
+  - 7.2
+  - 7.3
+cache:
+  directories:
+    - vendor
+    - $HOME/.composer/cache
+env:
+  matrix:
+    - DEPENDENCIES=""
+    - DEPENDENCIES="--prefer-lowest --prefer-stable"
+before_install:
+- if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then cp $HOME/.phpenv/versions/$(phpenv global)/etc/conf.d/xdebug.ini /tmp; fi
+- if [[ $TRAVIS_PHP_VERSION != '7.3' ]]; then phpenv config-rm xdebug.ini ; fi
+- composer self-update
+- composer validate
+install:
+- if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then composer require --dev phpstan/phpstan-shim ^0.9 friendsofphp/php-cs-fixer ^2.0; fi
+- pecl install -f swoole
+- echo 'extension = "swoole.so"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini;
+- php -m
+- composer update $DEPENDENCIES
+script:
+  - ./vendor/bin/phpunit $COVERAGE;
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/php-cs-fixer --dry-run -v fix; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then phpenv config-add /tmp/xdebug.ini; ./vendor/bin/phpunit --coverage-clover=coverage.clover; else ./vendor/bin/phpunit; fi
+after_script:
+- if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,15 +19,15 @@ before_install:
   - composer self-update
   - composer validate
 install:
-  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then composer require --dev phpstan/phpstan-shim ^0.9 friendsofphp/php-cs-fixer ^2.13; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then composer require --dev phpstan/phpstan-shim ^0.9 friendsofphp/php-cs-fixer ^2.13; fi
   - yes '' | pecl install swoole
   - php -m
   - composer update $DEPENDENCIES
   - php tests/bin/swoole.php &
 script:
   - ./vendor/bin/phpunit $COVERAGE;
-  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/php-cs-fixer --dry-run -v fix; fi
-  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi
-  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then phpenv config-add /tmp/xdebug.ini; ./vendor/bin/phpunit --coverage-clover=coverage.clover; else ./vendor/bin/phpunit; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then ./vendor/bin/php-cs-fixer --dry-run -v fix; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then ./vendor/bin/phpstan analyse -l max -c phpstan.neon src tests --no-progress --no-interaction; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then phpenv config-add /tmp/xdebug.ini; ./vendor/bin/phpunit --coverage-clover=coverage.clover; else ./vendor/bin/phpunit; fi
 after_script:
-- if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+- if [[ $TRAVIS_PHP_VERSION = '7.2' && DEPENDENCIES = '' ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ exit((require dirname(__DIR__) . '/vendor/bear/swoole/bootstrap.php')(
     'prod-hal-app',       // context
     'MyVendor\MyProject', // application name
     '127.0.0.1',          // IP
-    '8080'                // port
+    8080                  // port
 ));
 ```
 

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -35,6 +35,7 @@ return function (
 
             return;
         }
+        $app->requestContainer->set($request);
         $web = new WebContext($request);
         $match = $app->router->match($web->globals, $web->server);
         try {

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use BEAR\Package\AppInjector;
 use BEAR\Resource\ResourceObject;
 use BEAR\Swoole\App;
+use BEAR\Swoole\Psr7SwooleModule;
 use BEAR\Swoole\WebContext;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
@@ -30,7 +31,7 @@ return function (
     });
     $injector = new AppInjector($name, $context);
     /* @var App $app */
-    $app = $injector->getInstance(App::class);
+    $app = $injector->getOverrideInstance(new Psr7SwooleModule, App::class);
     $http->on('request', function (Request $request, Response $response) use ($app) {
         if ($app->httpCache->isNotModified($request->header)) {
             $app->httpCache->transfer($response);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use BEAR\Package\AppInjector;
 use BEAR\Resource\ResourceObject;
 use BEAR\Swoole\App;

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,14 @@
     "description": "Swoole script for BEAR.Sunday",
     "type": "library",
     "require": {
-        "php": ">=7.0.0"
+        "php": ">=7.1.0",
+        "ray/psr7-module": "^1.0",
+        "fastd/http": "^3.2"
     },
     "require-dev": {
-        "eaglewu/swoole-ide-helper": "dev-master"
+        "eaglewu/swoole-ide-helper": "dev-master",
+        "bear/package": "^1.9",
+        "phpunit/phpunit": "^7.4"
     },
     "license": "MIT",
     "authors": [
@@ -17,7 +21,12 @@
     ],
     "autoload": {
         "psr-4": {
-            "BEAR\\Swoole\\": "src/"
+            "BEAR\\Swoole\\": ["src/"]
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "BEAR\\Swoole\\": ["tests/"]
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "eaglewu/swoole-ide-helper": "dev-master",
         "bear/package": "^1.9",
         "phpunit/phpunit": "^7.4",
-        "bear/skeleton": "^1.6"
+        "bear/skeleton": "^1.6",
+        "guzzlehttp/guzzle": "^6.3"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     "require-dev": {
         "eaglewu/swoole-ide-helper": "dev-master",
         "bear/package": "^1.9",
-        "phpunit/phpunit": "^7.4"
+        "phpunit/phpunit": "^7.4",
+        "bear/skeleton": "^1.6"
     },
     "license": "MIT",
     "authors": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,3 @@
+parameters:
+	ignoreErrors:
+		- '#__construct\(\) does not call parent constructor#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit bootstrap="./vendor/autoload.php">
     <testsuites>
-        <testsuite>
+        <testsuite name="unit test">
             <directory suffix="Test.php">tests</directory>
         </testsuite>
     </testsuites>
@@ -13,3 +13,4 @@
         </whitelist>
     </filter>
 </phpunit>
+

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,15 @@
+<phpunit bootstrap="./vendor/autoload.php">
+    <testsuites>
+        <testsuite>
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <ini name="error_reporting" value="-1" />
+    </php>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/App.php
+++ b/src/App.php
@@ -35,17 +35,24 @@ final class App extends AbstractApp
      */
     public $error;
 
+    /**
+     * @var SwooleRequestContainer
+     */
+    public $requestContainer;
+
     public function __construct(
         HttpCache $httpCache,
         RouterInterface $router,
         Responder $responder,
         ResourceInterface $resource,
-        Error $error
+        Error $error,
+        SwooleRequestContainer $swoolRequestContainer
     ) {
         $this->httpCache = $httpCache;
         $this->router = $router;
         $this->responder = $responder;
         $this->resource = $resource;
         $this->error = $error;
+        $this->requestContainer = $swoolRequestContainer;
     }
 }

--- a/src/Error.php
+++ b/src/Error.php
@@ -10,10 +10,10 @@ use BEAR\Resource\Exception\ResourceNotFoundException as NotFound;
 use BEAR\Resource\Exception\ServerErrorException as ServerError;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
-use function get_class;
-use function json_encode;
 use const JSON_PRETTY_PRINT;
 use const PHP_EOL;
+use function get_class;
+use function json_encode;
 
 final class Error
 {
@@ -24,7 +24,7 @@ final class Error
         if ($this->isCodeExists($e)) {
             $code = $e->getCode();
             $response->status($code);
-            $response->end(sprintf("%s %s\n", (string)$code, (new Code)->statusText[$code]));
+            $response->end(sprintf("%s %s\n", (string) $code, (new Code)->statusText[$code]));
 
             return;
         }
@@ -47,7 +47,7 @@ final class Error
 
     private function isCodeExists(\Exception $e) : bool
     {
-        if (!($e instanceof NotFound) && !($e instanceof BadRequest) && !($e instanceof ServerError)) {
+        if (! ($e instanceof NotFound) && ! ($e instanceof BadRequest) && ! ($e instanceof ServerError)) {
             return false;
         }
 

--- a/src/Psr7SwooleModule.php
+++ b/src/Psr7SwooleModule.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace BEAR\Swoole;
 
 use Ray\Di\AbstractModule;

--- a/src/Psr7SwooleModule.php
+++ b/src/Psr7SwooleModule.php
@@ -1,0 +1,15 @@
+<?php
+namespace BEAR\Swoole;
+
+use Ray\Di\AbstractModule;
+use Ray\Di\Scope;
+use Ray\HttpMessage\RequestProviderInterface;
+
+class Psr7SwooleModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(RequestProviderInterface::class)->to(SwooleRequestProvider::class);
+        $this->bind(SwooleRequestContainer::class)->in(Scope::SINGLETON);
+    }
+}

--- a/src/Responder.php
+++ b/src/Responder.php
@@ -15,18 +15,18 @@ final class Responder implements TransferInterface
      */
     private $response;
 
-    public function setResponse(Response $response)
-    {
-        $this->response = $response;
-    }
-
     public function __invoke(ResourceObject $ro, array $server)
     {
         $ro->toString();
         foreach ($ro->headers as $key => $value) {
-            $this->response->header($key, (string)$value);
+            $this->response->header($key, (string) $value);
         }
         $this->response->status($ro->code);
         $this->response->end($ro->view);
+    }
+
+    public function setResponse(Response $response)
+    {
+        $this->response = $response;
     }
 }

--- a/src/SwooleRequestContainer.php
+++ b/src/SwooleRequestContainer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace BEAR\Swoole;
 
 use Swoole\Http\Request;

--- a/src/SwooleRequestContainer.php
+++ b/src/SwooleRequestContainer.php
@@ -1,0 +1,23 @@
+<?php
+namespace BEAR\Swoole;
+
+use Swoole\Http\Request;
+
+final class SwooleRequestContainer
+{
+    private $request;
+
+    public function set(Request $request) : void
+    {
+        $this->request = $request;
+    }
+
+    public function get() : Request
+    {
+        if (! $this->request instanceof Request) {
+            throw new \LogicException('Swoole request is unset.');
+        }
+
+        return $this->request;
+    }
+}

--- a/src/SwooleRequestProvider.php
+++ b/src/SwooleRequestProvider.php
@@ -1,0 +1,24 @@
+<?php
+namespace BEAR\Swoole;
+
+use FastD\Http\SwooleServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
+use Ray\HttpMessage\RequestProviderInterface;
+
+final class SwooleRequestProvider implements RequestProviderInterface
+{
+    /**
+     * @var SwooleRequestContainer
+     */
+    private $container;
+
+    public function __construct(SwooleRequestContainer $container)
+    {
+        $this->container = $container;
+    }
+
+    public function get() : ServerRequestInterface
+    {
+        return SwooleServerRequest::createServerRequestFromSwoole($this->container->get());
+    }
+}

--- a/src/SwooleRequestProvider.php
+++ b/src/SwooleRequestProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace BEAR\Swoole;
 
 use FastD\Http\SwooleServerRequest;

--- a/src/WebContext.php
+++ b/src/WebContext.php
@@ -33,7 +33,7 @@ final class WebContext
             'REQUEST_METHOD' => $request->server['request_method'],
             'REQUEST_URI' => $request->server['request_uri'],
             'CONTENT_TYPE' => $request->header['content-type'] ?? '',
-            'HTTP_RAW_POST_DATA' => $request->rawContent()
+            'HTTP_RAW_POST_DATA' => $request->rawcontent()
         ];
         $this->globals = [
             '_GET' => $request->get ?? [],

--- a/src/WebContext.php
+++ b/src/WebContext.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace BEAR\Swoole;
 
-use function file_put_contents;
 use Swoole\Http\Request;
 
 /**

--- a/tests/Psr7SwooleModuleTest.php
+++ b/tests/Psr7SwooleModuleTest.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace BEAR\Swoole;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Psr7SwooleModuleTest.php
+++ b/tests/Psr7SwooleModuleTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace BEAR\Swoole;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Ray\Di\Injector;
+use Swoole\Http\Request;
+
+class Psr7SwooleModuleTest extends TestCase
+{
+    public function testPsr7SwooleModule()
+    {
+        $injector = new Injector(new Psr7SwooleModule);
+        $requestProvider = $injector->getInstance(SwooleRequestProvider::class);
+        $swooleContainer = $injector->getInstance(SwooleRequestContainer::class);
+        $request = new Request;
+        $request->get = [];
+        $request->post = [];
+        $request->server = [
+            'request_method' => 'GET',
+            'request_uri' => '/',
+            'path_info' => '/',
+        ];
+        $request->header = [
+        ];
+        $request->cookie = [];
+        $swooleContainer->set($request);
+        $request = @$requestProvider->get();
+        $this->assertInstanceOf(RequestInterface::class, $request);
+    }
+}

--- a/tests/bin/BootstrapTest.php
+++ b/tests/bin/BootstrapTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Swoole;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class BootstrapTest extends TestCase
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    protected function setUp()
+    {
+        $this->client = new Client([
+            'base_uri' => 'http://127.0.0.1:8088'
+        ]);
+    }
+
+    public function testRequest()
+    {
+        $response = $this->client->get('/');
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('{
+    "greeting": "Hello BEAR.Sunday"
+}
+', (string) $response->getBody());
+    }
+}

--- a/tests/bin/swoole.php
+++ b/tests/bin/swoole.php
@@ -1,0 +1,8 @@
+<?php
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+exit((require dirname(__DIR__,2 ) . '/bootstrap.php')(
+    'prod-app',       // context
+    'BEAR\Skeleton',      // application name
+    '127.0.0.1',          // IP
+    '8080'                // port
+));

--- a/tests/bin/swoole.php
+++ b/tests/bin/swoole.php
@@ -1,6 +1,8 @@
 <?php
+
+declare(strict_types=1);
 require dirname(__DIR__, 2) . '/vendor/autoload.php';
-exit((require dirname(__DIR__,2 ) . '/bootstrap.php')(
+exit((require dirname(__DIR__, 2) . '/bootstrap.php')(
     'prod-app',       // context
     'BEAR\Skeleton',      // application name
     '127.0.0.1',          // IP

--- a/tests/bin/swoole.php
+++ b/tests/bin/swoole.php
@@ -6,5 +6,5 @@ exit((require dirname(__DIR__, 2) . '/bootstrap.php')(
     'prod-app',       // context
     'BEAR\Skeleton',      // application name
     '127.0.0.1',          // IP
-    '8080'                // port
+    8088                  // port
 ));

--- a/tests/swoole.ini
+++ b/tests/swoole.ini
@@ -1,0 +1,1 @@
+extension = "swoole.so"

--- a/tests/swoole.ini
+++ b/tests/swoole.ini
@@ -1,1 +1,0 @@
-extension = "swoole.so"

--- a/travis/modulecache.sh
+++ b/travis/modulecache.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+MODULE_CACHE_DIR=${TRAVIS_BUILD_DIR}/travis/module-cache/`php-config --vernum`
+INI_DIR=${TRAVIS_BUILD_DIR}/travis/ini/
+PHP_TARGET_DIR=`php-config --extension-dir`
+
+if [ -d ${MODULE_CACHE_DIR} ]
+then
+  cp ${MODULE_CACHE_DIR}/* ${PHP_TARGET_DIR}
+fi
+
+mkdir -p ${INI_DIR}
+mkdir -p ${MODULE_CACHE_DIR}
+
+for module in $MODULES
+do
+  FILENAME=`echo $module|cut -d : -f 1`
+  PACKAGE=`echo $module|cut -d : -f 2`
+  if [ ! -f ${PHP_TARGET_DIR}/${FILENAME} ]
+  then
+    echo "$FILENAME not found in extension dir, compiling"
+    printf "yes\n" | pecl install ${PACKAGE}
+  else
+    echo "Adding $FILENAME to php config"
+    echo "extension = $FILENAME" > ${INI_DIR}/${FILENAME}.ini
+    phpenv config-add ${INI_DIR}/${FILENAME}.ini
+  fi
+  cp ${PHP_TARGET_DIR}/${FILENAME} ${MODULE_CACHE_DIR}
+done


### PR DESCRIPTION
Support PSR7 ServerRequestInterface for swoole.
You can get web context (Superglobals in PHP, such as `$_SERVER` or `$_COOKIE`) through`RequestProviderInterface` privder.

```php
public function __construct(RequestProviderInterface $provider)
{
    $serverRequest = provider->get();
    $cookie = serverRequest->getCookieParams();
}
```
See more about PSR7 at [https://www.php-fig.org/psr/psr-7/](https://www.php-fig.org/psr/psr-7/)