### PR TITLE
Fix JSON request bodies and client-triggered worker crashes on Swoole

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -37,13 +37,14 @@ return static function (string $context, string $name, string $ip, int $port, ar
         // Seed the context for potential PSR-7 use. Conversion is lazy.
         $server = SwooleRequestProvider::seed($request);
 
-        // Check ETag from coroutine context directly.
-        if ($app->httpCache->isNotModified()) {
-            $app->httpCache->transfer($response);
-            return;
-        }
-
         try {
+            // Check ETag from coroutine context directly.
+            if ($app->httpCache->isNotModified()) {
+                $app->httpCache->transfer($response);
+
+                return;
+            }
+
             $match = $app->router->match(
                 [
                     '_GET' => $request->get ?? [],

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -43,15 +43,15 @@ return static function (string $context, string $name, string $ip, int $port, ar
             return;
         }
 
-        $match = $app->router->match(
-            [
-                '_GET' => $request->get ?? [],
-                '_POST' => $request->post ?? []
-            ],
-            $server
-        );
-
         try {
+            $match = $app->router->match(
+                [
+                    '_GET' => $request->get ?? [],
+                    '_POST' => $request->post ?? []
+                ],
+                $server
+            );
+
             $ro = $app->resource->newRequest(Method::from($match->method), $match->path, $match->query)();
 
             $app->responder->setResponse($response);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -58,7 +58,7 @@ return static function (string $context, string $name, string $ip, int $port, ar
             $app->responder->setResponse($response);
             $ro->transfer($app->responder, []);
 
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $app->error->transfer($e, $request, $response);
         }
     });

--- a/src/Error.php
+++ b/src/Error.php
@@ -8,9 +8,9 @@ use BEAR\Resource\Code;
 use BEAR\Resource\Exception\BadRequestException as BadRequest;
 use BEAR\Resource\Exception\ResourceNotFoundException as NotFound;
 use BEAR\Resource\Exception\ServerErrorException as ServerError;
-use Exception;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
+use Throwable;
 
 use function array_key_exists;
 use function error_log;
@@ -26,7 +26,7 @@ use const PHP_EOL;
  */
 final readonly class Error
 {
-    public function transfer(Exception $e, Request $request, Response $response): void
+    public function transfer(Throwable $e, Request $request, Response $response): void
     {
         $this->log($request, $e);
         $response->header('content-type', 'text/plain');
@@ -42,7 +42,7 @@ final readonly class Error
         $response->end('500 Server Error' . PHP_EOL);
     }
 
-    private function log(Request $request, Exception $e): void
+    private function log(Request $request, Throwable $e): void
     {
         error_log(
             (string) json_encode(
@@ -60,7 +60,7 @@ final readonly class Error
         );
     }
 
-    private function isCodeExists(Exception $e): bool
+    private function isCodeExists(Throwable $e): bool
     {
         if (! ($e instanceof NotFound) && ! ($e instanceof BadRequest) && ! ($e instanceof ServerError)) {
             return false;

--- a/src/HttpCache.php
+++ b/src/HttpCache.php
@@ -6,6 +6,7 @@ namespace BEAR\Swoole;
 
 use ArrayObject;
 use BEAR\QueryRepository\ResourceStorageInterface;
+use Psr\Cache\InvalidArgumentException;
 use Swoole\Coroutine;
 use Swoole\Http\Request;
 use Swoole\Http\Response;
@@ -23,8 +24,17 @@ final readonly class HttpCache implements HttpCacheInterface
     public function isNotModified(): bool
     {
         $etag = $this->getIfNoneMatch();
+        if ($etag === null) {
+            return false;
+        }
 
-        return $etag !== null && $this->storage->hasEtag($etag);
+        try {
+            return $this->storage->hasEtag($etag);
+        } catch (InvalidArgumentException) {
+            // RFC 9110 ETags (e.g. W/"abc") contain PSR-6 reserved characters;
+            // an ETag the pool cannot express is simply not a cache hit.
+            return false;
+        }
     }
 
     private function getIfNoneMatch(): ?string

--- a/src/SwooleServerRequestConverter.php
+++ b/src/SwooleServerRequestConverter.php
@@ -99,6 +99,13 @@ final readonly class SwooleServerRequestConverter
             $server[$key] = $value;
         }
 
+        // Swoole does not populate php://input, so expose the raw request body
+        // via HTTP_RAW_POST_DATA for BEAR.Sunday's router (JSON/form PUT/PATCH/DELETE).
+        $rawContent = $request->rawContent();
+        if (is_string($rawContent) && $rawContent !== '') {
+            $server['HTTP_RAW_POST_DATA'] = $rawContent;
+        }
+
         return $server;
     }
 

--- a/src/SwooleServerRequestConverter.php
+++ b/src/SwooleServerRequestConverter.php
@@ -101,6 +101,9 @@ final readonly class SwooleServerRequestConverter
 
         // Swoole does not populate php://input, so expose the raw request body
         // via HTTP_RAW_POST_DATA for BEAR.Sunday's router (JSON/form PUT/PATCH/DELETE).
+        // Drop any client-supplied "Raw-Post-Data" header first: it maps to the same
+        // key and would otherwise let a header inject the request body on an empty body.
+        unset($server['HTTP_RAW_POST_DATA']);
         $rawContent = $request->rawContent();
         if (is_string($rawContent) && $rawContent !== '') {
             $server['HTTP_RAW_POST_DATA'] = $rawContent;

--- a/tests/BootstrapTest.php
+++ b/tests/BootstrapTest.php
@@ -38,6 +38,18 @@ class BootstrapTest extends TestCase
         $this->assertSame('', (string) $response2->getBody());
     }
 
+    /** RFC 9110 ETags (e.g. W/"abc") contain PSR-6 reserved characters and must not crash the server */
+    public function testRfc9110EtagIsHandled(): void
+    {
+        $response = $this->client->get('/cache', [
+            'headers' => ['If-None-Match' => 'W/"abc"'],
+            'http_errors' => false,
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+        $alive = $this->client->get('/');
+        $this->assertSame(200, $alive->getStatusCode(), 'Server must survive an RFC 9110 formatted ETag');
+    }
+
 
 
     /** test @CookieParam, @FormParam, @QueryParam, @ServerParam annotated web context injection */

--- a/tests/Fake/src/Resource/Page/Ticket.php
+++ b/tests/Fake/src/Resource/Page/Ticket.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Skeleton\Resource\Page;
+
+use BEAR\Resource\ResourceObject;
+
+class Ticket extends ResourceObject
+{
+    public function onPost(string $title, int $qty): static
+    {
+        $this->body = ['title' => $title, 'qty' => $qty];
+
+        return $this;
+    }
+
+    public function onPut(string $title, int $qty): static
+    {
+        $this->body = ['title' => $title, 'qty' => $qty];
+
+        return $this;
+    }
+}

--- a/tests/FakeRawRequest.php
+++ b/tests/FakeRawRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Swoole;
+
+use Swoole\Http\Request;
+
+/**
+ * Swoole request double whose raw body can be controlled in-process.
+ *
+ * Swoole's native rawContent() always returns false on a hand-built
+ * Request, so this override lets unit tests exercise toGlobals() body
+ * handling without a running server.
+ */
+final class FakeRawRequest extends Request
+{
+    public string|false $rawBody = false;
+
+    public function rawContent(): string|false
+    {
+        return $this->rawBody;
+    }
+}

--- a/tests/Psr7SwooleModuleTest.php
+++ b/tests/Psr7SwooleModuleTest.php
@@ -34,6 +34,31 @@ class Psr7SwooleModuleTest extends TestCase
         $this->assertSame('value', $server['HTTP_X_CUSTOM']);
     }
 
+    public function testToGlobalsExposesRawBodyAsHttpRawPostData(): void
+    {
+        $request = new FakeRawRequest();
+        $request->server = ['request_method' => 'PUT'];
+        $request->header = ['content-type' => 'application/json'];
+        $request->rawBody = '{"title":"x"}';
+
+        $server = SwooleServerRequestConverter::toGlobals($request);
+
+        $this->assertSame('{"title":"x"}', $server['HTTP_RAW_POST_DATA']);
+    }
+
+    public function testToGlobalsDropsSpoofedRawPostDataHeader(): void
+    {
+        $request = new FakeRawRequest();
+        $request->server = ['request_method' => 'PUT'];
+        // Maps to HTTP_RAW_POST_DATA; must not be honoured as the body.
+        $request->header = ['raw-post-data' => 'injected'];
+        $request->rawBody = false;
+
+        $server = SwooleServerRequestConverter::toGlobals($request);
+
+        $this->assertArrayNotHasKey('HTTP_RAW_POST_DATA', $server);
+    }
+
     public function testCreateFromSwooleWithHttps(): void
     {
         /** @phpstan-ignore-next-line function.notFound */

--- a/tests/RequestBodyTest.php
+++ b/tests/RequestBodyTest.php
@@ -65,4 +65,41 @@ class RequestBodyTest extends TestCase
         $alive = $this->client->get('/');
         $this->assertSame(200, $alive->getStatusCode(), 'Server must survive an empty JSON request');
     }
+
+    /** A syntactically valid but non-object JSON body (e.g. 123) makes the router throw a TypeError, an Error not an Exception */
+    public function testScalarJsonBodyDoesNotCrashServer(): void
+    {
+        $response = $this->client->put('/ticket', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => '123',
+        ]);
+        $this->assertGreaterThanOrEqual(400, $response->getStatusCode());
+        $alive = $this->client->get('/');
+        $this->assertSame(200, $alive->getStatusCode(), 'Server must survive a scalar JSON body');
+    }
+
+    /** An unknown method override makes Method::from() throw a ValueError, an Error not an Exception */
+    public function testInvalidMethodOverrideDoesNotCrashServer(): void
+    {
+        $response = $this->client->post('/', [
+            'headers' => ['X-HTTP-Method-Override' => 'FOO'],
+        ]);
+        $this->assertGreaterThanOrEqual(400, $response->getStatusCode());
+        $alive = $this->client->get('/');
+        $this->assertSame(200, $alive->getStatusCode(), 'Server must survive an invalid method override');
+    }
+
+    /** A Raw-Post-Data header must not be honoured as the request body (empty real body) */
+    public function testRawPostDataHeaderCannotInjectBody(): void
+    {
+        $response = $this->client->put('/ticket', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Raw-Post-Data' => '{"title":"x","qty":1}',
+            ],
+        ]);
+        $this->assertSame(400, $response->getStatusCode());
+        $alive = $this->client->get('/');
+        $this->assertSame(200, $alive->getStatusCode(), 'Server must survive a Raw-Post-Data header');
+    }
 }

--- a/tests/RequestBodyTest.php
+++ b/tests/RequestBodyTest.php
@@ -44,4 +44,25 @@ class RequestBodyTest extends TestCase
 }
 ', (string) $response->getBody());
     }
+
+    public function testMalformedJsonReturns400(): void
+    {
+        $response = $this->client->put('/ticket', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body' => '{"title":}',
+        ]);
+        $this->assertSame(400, $response->getStatusCode());
+        $alive = $this->client->get('/');
+        $this->assertSame(200, $alive->getStatusCode(), 'Server must survive a malformed JSON request');
+    }
+
+    public function testEmptyJsonBodyReturns400(): void
+    {
+        $response = $this->client->put('/ticket', [
+            'headers' => ['Content-Type' => 'application/json'],
+        ]);
+        $this->assertSame(400, $response->getStatusCode());
+        $alive = $this->client->get('/');
+        $this->assertSame(200, $alive->getStatusCode(), 'Server must survive an empty JSON request');
+    }
 }

--- a/tests/RequestBodyTest.php
+++ b/tests/RequestBodyTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\Swoole;
+
+use GuzzleHttp\Client;
+use PHPUnit\Framework\TestCase;
+
+class RequestBodyTest extends TestCase
+{
+    private Client $client;
+
+    protected function setUp(): void
+    {
+        $this->client = new Client([
+            'base_uri' => 'http://127.0.0.1:8088',
+            'http_errors' => false,
+        ]);
+    }
+
+    public function testJsonPut(): void
+    {
+        $response = $this->client->put('/ticket', [
+            'json' => ['title' => 'hello', 'qty' => 3],
+        ]);
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertSame('{
+    "title": "hello",
+    "qty": 3
+}
+', (string) $response->getBody());
+    }
+
+    public function testJsonPost(): void
+    {
+        $response = $this->client->post('/ticket', [
+            'json' => ['title' => 'world', 'qty' => 5],
+        ]);
+        $this->assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $this->assertSame('{
+    "title": "world",
+    "qty": 5
+}
+', (string) $response->getBody());
+    }
+}


### PR DESCRIPTION
## What

Swoole never populates `php://input`, so BEAR.Sunday's router received an
empty body. That broke JSON/form request bodies and, worse, several
unhandled exceptions on the body/routing path escaped the request handler
and killed the entire Swoole worker — a client-triggered DoS.

## Changes

- **Request body** — expose Swoole's `rawContent()` as `HTTP_RAW_POST_DATA`
  in `toGlobals()`, so JSON/form `PUT/POST/PATCH/DELETE` bodies reach the
  router instead of arriving empty.
- **Router exceptions** — move `router->match()` inside the try/catch; a
  malformed/empty JSON body now returns `400` instead of crashing the worker.
- **Conditional requests** — RFC 9110 ETags (e.g. `W/"abc"`) contain PSR-6
  reserved characters; treat an unparseable `If-None-Match` as a cache miss
  instead of letting Symfony Cache throw and kill the worker.
- **Error-family throwables & header injection** — widen the handler's catch
  to `Throwable` (a scalar JSON body → `TypeError`, an unknown method →
  `ValueError`; both mapped to `500`, matching the FPM stack), and drop any
  client-supplied `Raw-Post-Data` header before setting the body.

## Testing

Integration tests cover each vector (JSON round-trips, malformed/empty JSON,
RFC 9110 ETag, scalar JSON, method override, header injection), each
asserting the correct status **and** that the server keeps serving. All 4
commits are individually green (bisect-safe).